### PR TITLE
Feat(Demo): Add Express HTTP adapter with resettable demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Loophole-Bookings
 
 This repository contains my thesis project, “Loophole” which focuses on isolating, implementing and testing the core domain logic for a booking system.
+
+## Demo UI
+
+The project includes a small demo UI exposed through an Express server.
+The purpose of the demo is to visualize how the domain use cases behavewhen accessed through an HTTP-based presentation layer.
+
+The demo UI:
+
+- Uses the same application-layer use cases as the CLI demos
+- Runs entirely in memory
+- Can be reset to a known state between demonstrations
+
+npm run demo:ui
+http://localhost:5050/api/health => Proves that express routing works
+http://localhost:5050/api/rooms => Rooms endpoint proves that seed, listRooms and roomView mapper works correctly

--- a/demo/cancelBooking.js
+++ b/demo/cancelBooking.js
@@ -1,7 +1,7 @@
 import { Room } from '../src/domain/entities/Room.js';
 import { createBooking } from '../src/domain/application/use-cases/createBooking.js';
 import { cancelBooking } from '../src/domain/application/use-cases/cancelBooking.js';
-import { InMemoryRoomStore } from './store.js';
+import { InMemoryRoomStore } from './inMemoryRoomStore.js';
 import { bookingView } from './utils.js';
 
 /** Demo 5.2 UC2 - Cancel Booking (admin)

--- a/demo/createBooking.js
+++ b/demo/createBooking.js
@@ -1,6 +1,6 @@
 import { Room } from '../src/domain/entities/Room.js';
 import { createBooking } from '../src/domain/application/use-cases/createBooking.js';
-import { InMemoryRoomStore } from './store.js';
+import { InMemoryRoomStore } from './inMemoryRoomStore.js';
 import { bookingView } from './utils.js';
 
 /**

--- a/demo/denyUnauthorizedCancel.js
+++ b/demo/denyUnauthorizedCancel.js
@@ -2,7 +2,7 @@ import { Room } from '../src/domain/entities/Room.js';
 import { createBooking } from '../src/domain/application/use-cases/createBooking.js';
 import { cancelBooking } from '../src/domain/application/use-cases/cancelBooking.js';
 import { bookingView } from './utils.js';
-import { InMemoryRoomStore } from './store.js';
+import { InMemoryRoomStore } from './inMemoryRoomStore.js';
 
 /**
  * Demo 5.3 UC2 - Cancel Booking (unauthorized)

--- a/demo/inMemoryRoomStore.js
+++ b/demo/inMemoryRoomStore.js
@@ -1,0 +1,56 @@
+/**
+ * In-memory implementation of a RoomStore.
+ *
+ * Acts as a fake persistence layer for demos and tests.
+ * Replaces a real database while keeping the domain logic unchanged.
+ *
+ * Key purposes:
+ * - Stores Room aggregates in memory.
+ * - Does not contain any domain rules.
+ * - Does not know anything about demo lifecycle or reset.
+ *
+ * This design allows the application and domain layers
+ * to depend on abstractions rather than concrete infrastructure.
+ */
+
+export class InMemoryRoomStore {
+  #rooms;
+
+  constructor(rooms = []) {
+    // Copy the array to avoid external mutation of internal state
+    this.#rooms = [...rooms];
+  }
+
+  /**
+   * Returns all rooms in the store.
+   * Note:
+   * - Returns a shallow copy to protect internal state.
+   * - Rooms themselves are immutable aggregate roots.
+   */
+  listRooms() {
+    return [...this.#rooms];
+  }
+
+  /**
+   * Fetch a single room by id.
+   * Used in demos to verify state after a use case has run.
+   */
+  getRoomById(id) {
+    return this.#rooms.find((r) => r.id === id);
+  }
+
+  /**
+   * Persist an updated Room aggregate.
+   * In a real system this would be a database update.
+   * Here we simply replace the room in memory.
+   */
+  saveRoom(updatedRoom) {
+    const exists = this.#rooms.some((r) => r.id === updatedRoom.id);
+    if (!exists) {
+      throw new Error(`Room not found: ${updatedRoom.id}`);
+    }
+    this.#rooms = this.#rooms.map((r) =>
+      r.id === updatedRoom.id ? updatedRoom : r
+    );
+  }
+}

--- a/demo/noAvailableRoom.js
+++ b/demo/noAvailableRoom.js
@@ -1,6 +1,6 @@
 import { Room } from '../src/domain/entities/Room.js';
 import { createBooking } from '../src/domain/application/use-cases/createBooking.js';
-import { InMemoryRoomStore } from './store.js';
+import { InMemoryRoomStore } from './inMemoryRoomStore.js';
 import { bookingView } from './utils.js';
 
 /**

--- a/demo/store.js
+++ b/demo/store.js
@@ -1,54 +1,37 @@
+import { InMemoryRoomStore } from './inMemoryRoomStore.js';
+import { Room } from '../src/domain/entities/Room.js';
+
 /**
- * Implementation of in-memory RoomStore
+ * DEMO STORE for demo purposes
+ * This file owns the demo lifecycle (seed + reset)
+ * Can be resettable between demo runs or requests (for UI server)
  *
- * Purpose:
- * - Used exclusively for demos and tests.
- * - Mimics a persistence layer without involving a database or API.
+ * Important:
+ * - The InMemoryRoomStore itself contains no demo logic.
+ * - Reset functionality is intentionally placed here to avoid polluting the infrastructure layer.
  *
  * Why this matters in the exam:
- * - Demonstrates that the application layer depends on abstractions,
- *   not concrete infrastructure.
- * - Makes the domain logic fully testable and demoable in isolation.
+ * - Demonstrates separation of concerns.
+ * - Shows how the same infrastructure can be reused
+ *   in tests, demos and other adapters.
  */
 
-export class InMemoryRoomStore {
-  #rooms;
+export function createDemoStore() {
+  const buildRoomStore = () =>
+    new InMemoryRoomStore([
+      // Bookings: [] is ALWAYS required to avoid undefined, This is correct initialization of aggregaete root
+      new Room({ id: 'room-1', capacity: 2, bookings: [] }),
+      new Room({ id: 'room-2', capacity: 4, bookings: [] }),
+    ]);
 
-  constructor(rooms = []) {
-    // Copy the array to avoid external mutation of internal state
-    this.#rooms = rooms;
-  }
+  let roomStore = buildRoomStore();
 
-  /**
-   * Returns all rooms in the store.
-   * Note:
-   * - Returns a shallow copy to protect internal state.
-   * - Rooms themselves are immutable aggregate roots.
-   */
-  listRooms() {
-    return [...this.#rooms];
-  }
-
-  /**
-   * Fetch a single room by id.
-   * Used in demos to verify state after a use case has run.
-   */
-  getRoomById(id) {
-    return this.#rooms.find((r) => r.id === id);
-  }
-
-  /**
-   * Persist an updated Room aggregate.
-   * In a real system this would be a database update.
-   * Here we simply replace the room in memory.
-   */
-  saveRoom(updatedRoom) {
-    const exists = this.#rooms.some((r) => r.id === updatedRoom.id);
-    if (!exists) {
-      throw new Error(`Room not found: ${updatedRoom.id}`);
-    }
-    this.#rooms = this.#rooms.map((r) =>
-      r.id === updatedRoom.id ? updatedRoom : r
-    );
-  }
+  return {
+    listRooms: () => roomStore.listRooms(),
+    getRoomById: (id) => roomStore.getRoomById(id),
+    saveRoom: (room) => roomStore.saveRoom(room),
+    reset: () => {
+      roomStore = buildRoomStore();
+    },
+  };
 }

--- a/demo/ui-server.js
+++ b/demo/ui-server.js
@@ -1,0 +1,87 @@
+import express from 'express';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createBooking } from '../src/domain/application/use-cases/createBooking.js';
+import { cancelBooking } from '../src/domain/application/use-cases/cancelBooking.js';
+import { DomainError } from '../src/domain/errors/DomainError.js';
+
+import { createDemoStore } from './store.js';
+import { roomView, bookingView } from './view.js';
+
+/**
+ * Demo UI adapter
+ * - Exposes a minimal REST API for the booking domain
+ * - Serves a static HTML/JS frontend for interaction
+ * - Separates domain logic and presentation
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+app.use(express.json());
+
+// Controlled in-memory state for demo purposes, can be resetted between requests
+const store = createDemoStore();
+
+// Serve static UI
+app.use(express.static(path.join(__dirname, 'public')));
+
+// Health [Debugging]
+app.get('/api/health', (req, res) => {
+  res.json({ ok: true });
+});
+
+app.get('/api/rooms', (req, res) => {
+  const rooms = store.listRooms();
+  res.json(rooms.map(roomView));
+});
+
+app.post('/api/bookings', (req, res) => {
+  try {
+    const booking = createBooking(req.body, store);
+    res.status(201).json(bookingView(booking));
+  } catch (err) {
+    if (err instanceof DomainError) {
+      res.status(400).json({ type: 'DOMAIN_ERROR', message: err.message });
+      return;
+    }
+    res
+      .status(500)
+      .json({ type: 'INTERNAL_ERROR', message: 'Unexpected error' });
+  }
+});
+
+app.post('/api/bookings/:id/cancel', (req, res) => {
+  try {
+    const booking = cancelBooking(
+      { bookingId: req.params.id, isAdmin: Boolean(req.body?.isAdmin) },
+      store
+    );
+    res.json(bookingView(booking));
+  } catch (err) {
+    if (err instanceof DomainError) {
+      res.status(400).json({ type: 'DOMAIN_ERROR', message: err.message });
+      return;
+    }
+    res
+      .status(500)
+      .json({ type: 'INTERNAL_ERROR', message: 'Unexpected error' });
+  }
+});
+
+/**
+ * Resetter endpoint for demo purposes
+ * - Resets the in-memory store to initial state
+ */
+app.post('/api/reset', (req, res) => {
+  console.log('RESET DEMO');
+  store.reset();
+  res.json({ ok: true });
+});
+
+const port = Number(process.env.PORT ?? 5050);
+app.listen(port, () => {
+  console.log(`Demo UI running on http://localhost:${port}`);
+});

--- a/demo/view.js
+++ b/demo/view.js
@@ -1,0 +1,47 @@
+/**
+ * View mappers, one of the most important parts of the demo! This is the translator between Domain and UI.
+ * UI will never know how the domain looks like internally.
+ *
+ * Purpose:
+ * - Convert domain objects into UI-safe JSON (primitives only).
+ * - Prevent leaking domain internals (value objects, Dates etc) into the presentation layer.
+ * - Keep demo UI stable even if domain internals evolve.
+ */
+
+const toIsoDate = (value) => {
+  if (!value) return null;
+
+  // If value is a Date object
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+
+  // If value is already a string like "2026-02-01"
+  if (typeof value === 'string') {
+    // Keep as it is, but normalize if it includes time
+    return value.length >= 10 ? value.slice(0, 10) : value;
+  }
+
+  return String(value);
+};
+
+// UI does not care about how bookings store date ranges internally - so we use only primitives
+export const bookingView = (b) => {
+  const from = b.from ?? b.dateRange?.from;
+  const to = b.to ?? b.dateRange?.to;
+
+  return {
+    id: b.id,
+    guests: b.guests,
+    status: b.status,
+    from: toIsoDate(from),
+    to: toIsoDate(to),
+  };
+};
+
+// Aggregated view of Room for UI purposes, protects UI from null or undefined bookings
+export const roomView = (r) => ({
+  id: r.id,
+  capacity: r.capacity,
+  bookings: (r.bookings ?? []).map(bookingView),
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "demo:5.3": "node demo/denyUnauthorizedCancel.js",
     "demo:5.4": "node demo/noAvailableRoom.js",
     "demo": "npm run demo:5.1 && npm run demo:5.2 && npm run demo:5.3 && npm run demo:5.4",
+    "demo:ui": "node demo/ui-server.js",
     "prepare": "husky"
   },
   "repository": {


### PR DESCRIPTION
This PR includes a small demo UI exposed through an Express server.
The purpose of the demo is to visualize how the domain use cases behave when accessed through an HTTP-based presentation layer.

I use view mappers as a presentation layer. 
The domain objects contain value objects and intrenal structures that are not exposable to the UI. By mapping JSON structures - the domain can grow without the UI being affected. 